### PR TITLE
[OSC-973] Add logging for configuration file parsing

### DIFF
--- a/modules/DataLoadManager.py
+++ b/modules/DataLoadManager.py
@@ -37,9 +37,8 @@ class DataLoadManager(object):
                 json_file.seek(0)
                 pipeline_configuration = json.load(json_file)
             pass
-
-        except JSONDecodeError:
-            self.logger.info(f"Parsing failed for: '{model_name}'")
+        except JSONDecodeError as exception:
+            self.logger.error(f"Parsing failed with message: '{str(exception)}'")
             raise
 
         self.logger.info(f"Execute Starting for: {model_name} requested_full_refresh: {requested_full_refresh}")

--- a/modules/DataLoadManager.py
+++ b/modules/DataLoadManager.py
@@ -3,6 +3,7 @@ import json
 import uuid
 import logging
 import hashlib
+from json import JSONDecodeError
 
 from modules.BatchDataLoader import BatchDataLoader
 from modules.DestinationTableManager import DestinationTableManager
@@ -28,10 +29,18 @@ class DataLoadManager(object):
 
         config_file = os.path.abspath(self.configuration_path + model_name)
         self.logger.debug("Using configuration file : {0}".format(config_file))
-        with open(config_file) as json_file:
-            model_checksum = hashlib.md5(json_file.read().encode('utf-8')).hexdigest()
-            json_file.seek(0)
-            pipeline_configuration = json.load(json_file)
+
+        try:
+            self.logger.info(f"Parsing started for: '{model_name}'")
+            with open(config_file) as json_file:
+                model_checksum = hashlib.md5(json_file.read().encode('utf-8')).hexdigest()
+                json_file.seek(0)
+                pipeline_configuration = json.load(json_file)
+            pass
+
+        except JSONDecodeError:
+            self.logger.info(f"Parsing failed for: '{model_name}'")
+            raise
 
         self.logger.info(
             "Execute Starting for: {0} requested_full_refresh: {1}".format(model_name, requested_full_refresh))

--- a/modules/DataLoadManager.py
+++ b/modules/DataLoadManager.py
@@ -31,14 +31,15 @@ class DataLoadManager(object):
         self.logger.debug(f"Using configuration file : {config_file}")
 
         try:
-            self.logger.info(f"Parsing started for: '{model_name}'")
+            self.logger.info(f"Loading configuration file: '{model_name}'")
             with open(config_file) as json_file:
                 model_checksum = hashlib.md5(json_file.read().encode('utf-8')).hexdigest()
                 json_file.seek(0)
                 pipeline_configuration = json.load(json_file)
+                self.logger.info(f"Loaded configuration file: '{model_name}'")
             pass
         except JSONDecodeError as exception:
-            self.logger.error(f"Parsing failed with message: '{str(exception)}'")
+            self.logger.error(f"Loading configuration file failed with message: '{str(exception)}'")
             raise exception
 
         self.logger.info(f"Execute Starting for: {model_name} requested_full_refresh: {requested_full_refresh}")

--- a/modules/DataLoadManager.py
+++ b/modules/DataLoadManager.py
@@ -25,10 +25,10 @@ class DataLoadManager(object):
         self.logger.info("Execution completed.")
 
     def start_single_import(self, target_engine, model_name, requested_full_refresh):
-        self.logger.debug("Using configuration file : {0}".format(model_name))
+        self.logger.debug(f"Using configuration file : {model_name}")
 
         config_file = os.path.abspath(self.configuration_path + model_name)
-        self.logger.debug("Using configuration file : {0}".format(config_file))
+        self.logger.debug(f"Using configuration file : {config_file}")
 
         try:
             self.logger.info(f"Parsing started for: '{model_name}'")
@@ -42,8 +42,7 @@ class DataLoadManager(object):
             self.logger.info(f"Parsing failed for: '{model_name}'")
             raise
 
-        self.logger.info(
-            "Execute Starting for: {0} requested_full_refresh: {1}".format(model_name, requested_full_refresh))
+        self.logger.info(f"Execute Starting for: {model_name} requested_full_refresh: {requested_full_refresh}")
 
         destination_table_manager = DestinationTableManager(target_engine)
 
@@ -52,9 +51,8 @@ class DataLoadManager(object):
         if not requested_full_refresh and not destination_table_manager.table_exists(
                 pipeline_configuration['target_schema'],
                 pipeline_configuration['load_table']):
-            self.logger.warning("The load table {0}.{1} does not exist. Swapping to full-refresh mode".format(
-                pipeline_configuration['target_schema'],
-                pipeline_configuration['load_table']))
+            self.logger.warning(f"The load table {pipeline_configuration['target_schema']}. "
+                                f"{pipeline_configuration['load_table']} does not exist. Swapping to full-refresh mode")
 
             full_refresh_reason = "Destination table does not exist"
             full_refresh = True
@@ -71,8 +69,8 @@ class DataLoadManager(object):
             full_refresh = True
         else:
             self.logger.debug(
-                "Previous Checksum {0}. Current Checksum {1}".format(last_successful_data_load_execution.model_checksum,
-                                                                     model_checksum))
+                f"Previous Checksum {last_successful_data_load_execution.model_checksum}. "
+                f"Current Checksum {model_checksum}")
             last_sync_version = last_successful_data_load_execution.next_sync_version
             if not full_refresh and last_successful_data_load_execution.model_checksum != model_checksum:
                 self.logger.info("A model checksum change has forced this to be a full load")
@@ -93,8 +91,8 @@ class DataLoadManager(object):
         columns = pipeline_configuration['columns']
         destination_table_manager.create_schema(pipeline_configuration['target_schema'])
 
-        self.logger.debug("Recreating the staging table {0}.{1}".format(pipeline_configuration['target_schema'],
-                                                                        pipeline_configuration['stage_table']))
+        self.logger.debug(f"Recreating the staging table {pipeline_configuration['target_schema']}."
+                          f"{pipeline_configuration['stage_table']}")
         destination_table_manager.create_table(pipeline_configuration['target_schema'],
                                                pipeline_configuration['stage_table'],
                                                columns, drop_first=True)
@@ -132,4 +130,4 @@ class DataLoadManager(object):
                                                  pipeline_configuration['stage_table'])
         data_load_tracker.completed_successfully()
         self.data_load_tracker_repository.save(data_load_tracker)
-        self.logger.info("Import Complete for: {0}. {1}".format(model_name, data_load_tracker.get_statistics()))
+        self.logger.info(f"Import Complete for: {model_name}. {data_load_tracker.get_statistics()}")

--- a/modules/DataLoadManager.py
+++ b/modules/DataLoadManager.py
@@ -3,8 +3,8 @@ import json
 import uuid
 import logging
 import hashlib
-from json import JSONDecodeError
 
+from json import JSONDecodeError
 from modules.BatchDataLoader import BatchDataLoader
 from modules.DestinationTableManager import DestinationTableManager
 from modules.data_load_tracking.DataLoadTracker import DataLoadTracker

--- a/modules/DataLoadManager.py
+++ b/modules/DataLoadManager.py
@@ -39,7 +39,7 @@ class DataLoadManager(object):
             pass
         except JSONDecodeError as exception:
             self.logger.error(f"Parsing failed with message: '{str(exception)}'")
-            raise
+            raise exception
 
         self.logger.info(f"Execute Starting for: {model_name} requested_full_refresh: {requested_full_refresh}")
 


### PR DESCRIPTION
# Changes
- Formatted `modules/DataLoadManager.py`
- Use f-string literals in place of string format (apparently it's [faster](https://cito.github.io/blog/f-strings/))
- Encapsulate loading of json configuration files in try/catch block
- Add informative logging for configuration file load